### PR TITLE
Obtain oversampled PSF image with correct pixel response

### DIFF
--- a/roman_imsim/utils.py
+++ b/roman_imsim/utils.py
@@ -119,7 +119,7 @@ class roman_utils(object):
         return point.drawImage(self.bpass,
                                 method='phot',
                                 rng=self.rng,
-                                maxN=1e6,
+                                maxN=int(1e6),
                                 n_photons=int(n_phot),
                                 image=stamp,
                                 photon_ops=photon_ops,

--- a/roman_imsim/utils.py
+++ b/roman_imsim/utils.py
@@ -15,7 +15,7 @@ class roman_utils(object):
         Setup information about a simulated Roman image.
         Parameters:
             config_file: the GalSim config file that produced the simulation
-            visit: the visit (observation sequence) number of the pointing 
+            visit: the visit (observation sequence) number of the pointing
             sca: the SCA number
             image_name: the filename of the image (can be used instead of visit, sca)
             setup_skycat: setup the skycatalog information to have access to
@@ -98,9 +98,13 @@ class roman_utils(object):
             y: y-position in SCA
             pupil_bin: pupil image binning factor
             sed: SED to be used to draw the PSF - default is a flat SED.
-            oversampling_factor: factor by which to oversample native roman pixel_scale
+            oversampling_factor: factor by which to oversample native roman pixel scale
             include_photonOps: include additional contributions from other photon operators in effective psf image
-            include_pixel: convolve output by the Roman pixel (default: False)
+            n_phot: Number of photons to generate PSF using photon shooting method.
+                    Relevant only if include_photonOps is True (default: 1e6)
+            method: Method used to generate the PSF image.
+                    Relevant only if include_photoOps is False (default: 'no_pixel')
+            include_pixel: convolve output to have the Roman pixel response (default: False)
         Returns:
             the PSF GalSim image object (use image.array to get a numpy array representation)
         """

--- a/roman_imsim/utils.py
+++ b/roman_imsim/utils.py
@@ -32,7 +32,7 @@ class roman_utils(object):
         self.wcs        = galsim.config.BuildWCS(config['image'], 'wcs', config)
         self.bpass      = galsim.config.BuildBandpass(config['image'], 'bandpass', config, None)[0]
         self.photon_ops = galsim.config.BuildPhotonOps(config['stamp'], 'photon_ops', config, None)
-        self.rng        = galsim.config.GetRNG(config, config['image'], None, "psf_image")
+        self.rng        = galsim.config.GetRNG(config, config['image'], None, "roman_sca")
 
     def check_input(self,visit,sca,image_name):
         if image_name is not None:
@@ -86,7 +86,7 @@ class roman_utils(object):
         return self.bpass
 
     def getPSF_Image(self,stamp_size,x=None,y=None,pupil_bin=8,sed=None,
-                        oversampling_factor=1,include_photonOps=False,n_phot=1e6):
+                        oversampling_factor=1,include_photonOps=False,n_phot=1e6,method='no_pixel'):
         """
         Return a Roman PSF image for some image position
         Parameters:
@@ -101,9 +101,9 @@ class roman_utils(object):
             the PSF GalSim image object (use image.array to get a numpy array representation)
         """
         if sed is None:
-            sed = galsim.SED(galsim.LookupTable([100, 2600], [1,1], interpolant='linear'),
+            sed = galsim.SED(galsim.LookupTable([400, 2600], [1,1], interpolant='linear'),
                               wave_type='nm', flux_type='fphotons')
-        point = galsim.DeltaFunction()*sed
+        point = galsim.DeltaFunction(flux=1)*sed
         point = point.withFlux(1,self.bpass)
         local_wcs = self.getLocalWCS(x,y)
         wcs = galsim.JacobianWCS(dudx=local_wcs.dudx/oversampling_factor,
@@ -113,13 +113,14 @@ class roman_utils(object):
         stamp = galsim.Image(stamp_size*oversampling_factor,stamp_size*oversampling_factor,wcs=wcs)
         if not include_photonOps:
             psf = galsim.Convolve(point, self.getPSF(x,y,pupil_bin))
-            return psf.drawImage(self.bpass,image=stamp,wcs=wcs,method='no_pixel')
+            print(method)
+            return psf.drawImage(self.bpass,image=stamp,wcs=wcs,method=method)
         photon_ops = [self.getPSF(x,y,pupil_bin)] + self.photon_ops
         return point.drawImage(self.bpass,
                                 method='phot',
                                 rng=self.rng,
                                 maxN=1e6,
-                                n_photons=1e6,
+                                n_photons=int(n_phot),
                                 image=stamp,
                                 photon_ops=photon_ops,
                                 poisson_flux=False)

--- a/roman_imsim/utils.py
+++ b/roman_imsim/utils.py
@@ -121,7 +121,6 @@ class roman_utils(object):
         stamp = galsim.Image(stamp_size*oversampling_factor,stamp_size*oversampling_factor,wcs=wcs)
         if not include_photonOps:
             psf = galsim.Convolve(point, self.getPSF(x,y,pupil_bin))
-            print(method)
             return psf.drawImage(self.bpass,image=stamp,wcs=wcs,method=method)
         photon_ops = [self.getPSF(x,y,pupil_bin)] + self.photon_ops
         if include_pixel and oversampling_factor > 1:

--- a/roman_imsim/utils.py
+++ b/roman_imsim/utils.py
@@ -86,7 +86,7 @@ class roman_utils(object):
         return self.bpass
 
     def getPSF_Image(self,stamp_size,x=None,y=None,pupil_bin=8,sed=None,
-                        oversampling_factor=1,include_photonOps=False,n_phot=1e6,method='no_pixel'):
+                        oversampling_factor=1,include_photonOps=False,n_phot=1e6,method='no_pixel',include_pixel=False):
         """
         Return a Roman PSF image for some image position
         Parameters:
@@ -97,6 +97,7 @@ class roman_utils(object):
             sed: SED to be used to draw the PSF - default is a flat SED.
             oversampling_factor: factor by which to oversample native roman pixel_scale
             include_photonOps: include additional contributions from other photon operators in effective psf image
+            include_pixel: convolve output by the Roman pixel (default: False)
         Returns:
             the PSF GalSim image object (use image.array to get a numpy array representation)
         """
@@ -116,6 +117,8 @@ class roman_utils(object):
             print(method)
             return psf.drawImage(self.bpass,image=stamp,wcs=wcs,method=method)
         photon_ops = [self.getPSF(x,y,pupil_bin)] + self.photon_ops
+        if include_pixel:
+            point = galsim.Convolve(point,galsim.Pixel(scale=0.11))
         return point.drawImage(self.bpass,
                                 method='phot',
                                 rng=self.rng,


### PR DESCRIPTION
This PR includes changes that ensure that an oversampled PSF image still contains the native pixel response. I am kind of surprised how the naive approach of convolving by the native pixel response function (`Overcounted pixel response`) is close to the correct thing (convolution with a grid of Dirac Delta functions). Leaving out either of these corrections (`Undercounted pixel response`) leads to a clear difference in the core of the PSF.

For a Gaussian object of `sigma=1/3` pixels, only the undercounted pixel response looks visually different. All plots shown here have `oversampling=3`.

<img width="1290" alt="image" src="https://github.com/user-attachments/assets/197f461a-35dc-4751-a304-bc4307bb4714" />

Taking a 1D slice through the center, the two correction methods are surprisingly (at least to me) very close to each other beyond what I would have naively thought.

<img width="864" alt="image" src="https://github.com/user-attachments/assets/65e25720-9fed-4da1-9e9a-f7b4c816b19c" />

Unsurprisingly, with a large object (`sigma=1` pixel), the agreement still holds very well.

<img width="904" alt="image" src="https://github.com/user-attachments/assets/43c7f8a2-df65-4503-8f37-3922756ef802" />


